### PR TITLE
Fix memory leaks in Aig::to_file and Aig::fmt

### DIFF
--- a/src/aiger.rs
+++ b/src/aiger.rs
@@ -290,6 +290,7 @@ impl Aig {
         let res = unsafe { aiger_write_to_file(aiger as _, mode, file) };
         assert!(res > 0, "write aig to {} failed", f.display());
         unsafe { fclose(file) };
+        unsafe { aiger_reset(aiger as _); }
     }
 }
 
@@ -302,7 +303,9 @@ unsafe extern "C" fn aiger_put(ch: c_char, state: *mut c_void) -> c_int {
 impl Display for Aig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         let aiger = self.to_aiger();
-        if unsafe { aiger_write_generic(aiger as _, 1, f as *mut _ as _, aiger_put) } > 0 {
+        let res = unsafe { aiger_write_generic(aiger as _, 1, f as *mut _ as _, aiger_put) };
+        unsafe { aiger_reset(aiger as _); }
+        if res > 0 {
             Ok(())
         } else {
             Err(fmt::Error)


### PR DESCRIPTION
.to_aiger() allocates (in C), and the result must be manually freed, which it previously was not, leading to leaked memory.